### PR TITLE
Add SCS support

### DIFF
--- a/tmt.c
+++ b/tmt.c
@@ -61,13 +61,14 @@ struct TMT{
     TMTPOINT curs, oldcurs;
     TMTATTRS attrs, oldattrs;
 
-    bool dirty, acs, ignored;
+    bool dirty, acs, ignored, decdraw;
     TMTSCREEN screen;
     TMTLINE *tabs;
 
     TMTCALLBACK cb;
     void *p;
     const wchar_t *acschars;
+    const wchar_t *decchars;
 
     mbstate_t ms;
     size_t nmb;
@@ -76,11 +77,19 @@ struct TMT{
     size_t pars[PAR_MAX];
     size_t npar;
     size_t arg;
-    enum {S_NUL, S_ESC, S_ARG} state;
+    enum {S_NUL, S_ESC, S_ARG, S_SCS} state;
 };
 
 static TMTATTRS defattrs = {.fg = TMT_COLOR_DEFAULT, .bg = TMT_COLOR_DEFAULT};
 static void writecharatcurs(TMT *vt, wchar_t w);
+
+static wchar_t
+decchar(const TMT *vt, unsigned char c)
+{
+    if (c > 94 && c < 127)
+        return vt->decchars[c - 95];
+    return (wchar_t)c;
+}
 
 static wchar_t
 tacs(const TMT *vt, unsigned char c)
@@ -279,7 +288,10 @@ handlechar(TMT *vt, char i)
     DO(S_ESC, "H",          t[c->c].c = L'*')
     DO(S_ESC, "7",          vt->oldcurs = vt->curs; vt->oldattrs = vt->attrs)
     DO(S_ESC, "8",          vt->curs = vt->oldcurs; vt->attrs = vt->oldattrs)
-    ON(S_ESC, "+*()",       vt->ignored = true; vt->state = S_ARG)
+    ON(S_ESC, "+*)",        vt->ignored = true; vt->state = S_ARG)
+    ON(S_ESC, "(",          vt->state = S_SCS)
+    DO(S_SCS, "0",          vt->decdraw = true)
+    DO(S_SCS, "B",          vt->decdraw = false)
     DO(S_ESC, "c",          tmt_reset(vt))
     ON(S_ESC, "[",          vt->state = S_ARG)
     ON(S_ARG, "\x1b",       vt->state = S_ESC)
@@ -356,6 +368,7 @@ tmt_open(size_t nline, size_t ncol, TMTCALLBACK cb, void *p,
 
     /* ASCII-safe defaults for box-drawing characters. */
     vt->acschars = acs? acs : L"><^v#+:o##+++++~---_++++|<>*!fo";
+    vt->decchars = L" ◆▒\t\f\r\n°±\n\v┘┐┌└┼⎺⎻─⎼⎽├┤┴┬│≤≥π≠£•";
     vt->cb = cb;
     vt->p = p;
     vt->attrs = vt->oldattrs = defattrs;
@@ -464,6 +477,8 @@ tmt_write(TMT *vt, const char *s, size_t n)
             continue;
         else if (vt->acs)
             writecharatcurs(vt, tacs(vt, (unsigned char)s[p]));
+        else if (vt->decdraw)
+            writecharatcurs(vt, decchar(vt, (unsigned char)s[p]));
         else if (vt->nmb >= BUF_MAX)
             writecharatcurs(vt, getmbchar(vt));
         else{


### PR DESCRIPTION
VT100 SCS is a method some software uses to do box drawing.  Add
support for it.

This fixes software that misrenders horizontal lines as the letter
q and some other character substitutions.

I did not stick to ASCII-safe characters, if desired someone could replace dec character set
with ascii-safe to be consistent with the ACS behavior.